### PR TITLE
Fix Markdown messages escaping

### DIFF
--- a/internal/service/bot/dafault_handler.go
+++ b/internal/service/bot/dafault_handler.go
@@ -64,11 +64,11 @@ func (s *Service) DefaultHandler(ctx context.Context, bot *tgbot.Bot, update *mo
 	s.addThreadMessage(messageThreadID, model.MessageTypeRequest, messageText)
 
 	for _, answer := range answers {
-		answerTest := escapeMarkdown(answer.Answer)
+		answerEsc := escapeMarkdown(answer.Answer)
     
 		_, err := bot.SendMessage(ctx, &tgbot.SendMessageParams{
 			ChatID: update.Message.Chat.ID,
-			Text:   answer.Answer,
+			Text:   answerEsc,
 			ReplyParameters: &models.ReplyParameters{
 				MessageID: update.Message.ID,
 			},

--- a/internal/service/bot/dafault_handler.go
+++ b/internal/service/bot/dafault_handler.go
@@ -63,12 +63,9 @@ func (s *Service) DefaultHandler(ctx context.Context, bot *tgbot.Bot, update *mo
 	s.addThreadMessage(messageThreadID, model.MessageTypeRequest, messageText)
 
 	for _, answer := range answers {
-		answerTest := tgbot.EscapeMarkdownUnescaped(answer.Answer)
-		answerTest = strings.ReplaceAll(answerTest, "\\`\\`\\`", "```")
-
 		_, err := bot.SendMessage(ctx, &tgbot.SendMessageParams{
 			ChatID: update.Message.Chat.ID,
-			Text:   answerTest,
+			Text:   answer.Answer,
 			ReplyParameters: &models.ReplyParameters{
 				MessageID: update.Message.ID,
 			},

--- a/internal/service/bot/dafault_handler_test.go
+++ b/internal/service/bot/dafault_handler_test.go
@@ -1,0 +1,28 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeMarkdownInlineCode(t *testing.T) {
+	t.Parallel()
+	input := "before _text_ `code_with_underscore` after."
+	expected := "before \\_text\\_ `code_with_underscore` after\\."
+	require.Equal(t, expected, escapeMarkdown(input))
+}
+
+func TestEscapeMarkdownFencedCode(t *testing.T) {
+	t.Parallel()
+	input := "before _text_\n```\nfenced_code_with_underscore\n```\nafter."
+	expected := "before \\_text\\_\n```\nfenced_code_with_underscore\n```\nafter\\."
+	require.Equal(t, expected, escapeMarkdown(input))
+}
+
+func TestEscapeMarkdownInlineAndFencedCode(t *testing.T) {
+	t.Parallel()
+	input := "escape _markdown_ `inline_code` and\n```\nfenced_code_with_underscore\n```\nfinish."
+	expected := "escape \\_markdown\\_ `inline_code` and\n```\nfenced_code_with_underscore\n```\nfinish\\."
+	require.Equal(t, expected, escapeMarkdown(input))
+}


### PR DESCRIPTION
## Summary
Removed automatic Markdown escaping when sending bot responses so Telegram can interpret the formatting correctly

## Testing
go test ./...